### PR TITLE
Implement DIY-DRM v2 scripts

### DIFF
--- a/checkingname.bat
+++ b/checkingname.bat
@@ -1,5 +1,11 @@
 @echo off
 
+REM Check if gettingname.bat exists, if so, run it
+if exist gettingname.bat (
+    echo Running gettingname.bat...
+    call gettingname.bat
+)
+
 REM Read stored hostname from .k77 file
 for /f %%A in (gamefile.k77) do set "STORED_HOSTNAME=%%A"
 
@@ -9,7 +15,15 @@ for /f %%A in ('hostname') do set "CURRENT_HOSTNAME=%%A"
 REM Check if the hostnames match
 if "%CURRENT_HOSTNAME%"=="%STORED_HOSTNAME%" (
     echo Hostname matches. Starting the game...
+    
+    REM Replace "gta6.exe" with the original executable name
+    ren "gta6.k77" "gta6.exe"
+    
+    REM Run the executable
     start gta6.exe
+    
+    REM Revert the filename extension back to .k77
+    ren "gta6.exe" "gta6.k77"
 ) else (
     echo Error: Hostname does not match. Game cannot run.
     pause

--- a/gettingname.bat
+++ b/gettingname.bat
@@ -3,11 +3,13 @@
 REM Get the hostname
 for /f %%A in ('hostname') do set "HOSTNAME=%%A"
 
-REM Save hostname to a file
-echo %HOSTNAME% > gamefile.txt
+REM Rename all .exe files to .k77
+for %%F in (*.exe) do (
+    ren "%%F" "%%~nF.k77"
+)
 
-REM Rename the file to .k77
-ren gamefile.txt gamefile.k77
+REM Save hostname to a file
+echo %HOSTNAME% > gamefile.k77
 
 REM Hide the .k77 file
 attrib +h gamefile.k77


### PR DESCRIPTION
Added version 2 (v2) of DIY-DRM scripts:

gettingname.bat: Enhancements include renaming all .exe files to .k77 and capturing the hostname. checkingname.bat: Improved logic to check hostnames, rename executable, and verify access before launching the game (betasux.k77 in this version). Enhancements in v2 now allow the checkingname.bat script to automatically execute gettingname.bat if present, eliminating the need for manual execution. The script verifies hostnames and manages access to the game by associating it with specific machine hostnames.