### PR TITLE
Added Cleanup Script

### DIFF
--- a/cleaner.bat
+++ b/cleaner.bat
@@ -1,0 +1,26 @@
+@echo off
+
+REM Check if gettingname.bat exists and delete it if found
+if exist gettingname.bat (
+    echo Deleting gettingname.bat...
+    del gettingname.bat
+)
+
+REM Check if checkingname.bat exists and delete it if found
+if exist checkingname.bat (
+    echo Deleting checkingname.bat...
+    del checkingname.bat
+)
+
+REM Unhide and check if gamefile.k77 exists, then delete it if found
+attrib -h gamefile.k77 2>nul
+if exist gamefile.k77 (
+    echo Deleting gamefile.k77...
+    del gamefile.k77
+)
+
+REM Change affected .k77 files back to .exe
+ren *.k77 *.exe 2>nul
+
+echo Cleanup completed.
+pause


### PR DESCRIPTION
**Description:**
Added a cleanup script (`cleanup.bat`) to manage removal of `gettingname.bat`, `checkingname.bat`, `gamefile.k77`, and revert affected `.k77` files back to `.exe`. This script offers a simple way to reset the DIY-DRM setup and clean the directory of associated files.